### PR TITLE
Implement riptide flight

### DIFF
--- a/src/main/java/de/gerrygames/viarewind/legacysupport/BukkitPlugin.java
+++ b/src/main/java/de/gerrygames/viarewind/legacysupport/BukkitPlugin.java
@@ -1,12 +1,7 @@
 package de.gerrygames.viarewind.legacysupport;
 
 import de.gerrygames.viarewind.legacysupport.injector.BoundingBoxFixer;
-import de.gerrygames.viarewind.legacysupport.listener.AreaEffectCloudListener;
-import de.gerrygames.viarewind.legacysupport.listener.BounceListener;
-import de.gerrygames.viarewind.legacysupport.listener.BrewingListener;
-import de.gerrygames.viarewind.legacysupport.listener.ElytraListener;
-import de.gerrygames.viarewind.legacysupport.listener.EnchantingListener;
-import de.gerrygames.viarewind.legacysupport.listener.SoundListener;
+import de.gerrygames.viarewind.legacysupport.listener.*;
 import de.gerrygames.viarewind.legacysupport.versioninfo.VersionInformer;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -43,6 +38,8 @@ public class BukkitPlugin extends JavaPlugin {
 					Bukkit.getPluginManager().registerEvents(new BounceListener(), BukkitPlugin.this);
 				if (ProtocolRegistry.SERVER_PROTOCOL > 76 && config.getBoolean("elytra-fix"))
 					Bukkit.getPluginManager().registerEvents(new ElytraListener(), BukkitPlugin.this);
+				if (ProtocolRegistry.SERVER_PROTOCOL > 392 && config.getBoolean("riptide-fix"))
+					Bukkit.getPluginManager().registerEvents(new RiptideListener(), BukkitPlugin.this);
 				if (ProtocolRegistry.SERVER_PROTOCOL > 54 && config.getBoolean("area-effect-cloud-particles"))
 					Bukkit.getPluginManager().registerEvents(new AreaEffectCloudListener(), BukkitPlugin.this);
 				if (config.getBoolean("versioninfo.active"))

--- a/src/main/java/de/gerrygames/viarewind/legacysupport/listener/RiptideListener.java
+++ b/src/main/java/de/gerrygames/viarewind/legacysupport/listener/RiptideListener.java
@@ -1,0 +1,37 @@
+package de.gerrygames.viarewind.legacysupport.listener;
+
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerRiptideEvent;
+import org.bukkit.util.Vector;
+import us.myles.ViaVersion.api.Via;
+
+public class RiptideListener implements Listener {
+    @EventHandler(ignoreCancelled = true)
+    public void onPlayerRiptide(PlayerRiptideEvent event) {
+        Player p = event.getPlayer();
+        if (Via.getAPI().getPlayerVersion(p)>392) return;
+
+        int level = event.getItem().getEnchantmentLevel(Enchantment.RIPTIDE);
+
+        float yaw = p.getLocation().getYaw();
+        float pitch = p.getLocation().getPitch();
+        double x = -Math.sin(yaw * (0.017453292f)) * Math.cos(pitch * (0.017453292f));
+        double y = -Math.sin(pitch * (0.017453292f));
+        double z = Math.cos(yaw * (0.017453292f)) * Math.cos(pitch * (0.017453292f));
+        double length = Math.sqrt(x * x + y * y + z * z);
+        float f5 = 3.0F * ((1.0F + (float)level) / 4.0F);
+        x = x * (f5 / length);
+        y = y * (f5 / length);
+        z = z * (f5 / length);
+
+        p.setVelocity(new Vector(x, y, z));
+
+        if (p.isOnGround()) {
+            p.setVelocity(new Vector(0.0D, 1.1999999F, 0.0D));
+        }
+
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -12,6 +12,8 @@ sound-fix: true
 slime-fix: true
 #If this plugin should apply velocity to 1.8 and lower clients to emulate elytra flight
 elytra-fix: true
+#If this plugin should apply velocity to 1.12 and lower clients to emulate riptide flight
+riptide-fix: true
 #
 area-effect-cloud-particles: true
 #Inform your players that they are using an outdated minecraft version


### PR DESCRIPTION
This PR implements the code needed to allow players on old versions to riptide.

It makes use of a spigot event as it gets fired although the movement is implemented client-side.

I'm not sure if the protocol version is correct, but should be.