### PR TITLE
Fix 1.7 carpets collision on 1.14+ servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.iml
 .idea/
 build/
+target/

--- a/src/main/java/de/gerrygames/viarewind/legacysupport/BukkitPlugin.java
+++ b/src/main/java/de/gerrygames/viarewind/legacysupport/BukkitPlugin.java
@@ -36,6 +36,8 @@ public class BukkitPlugin extends JavaPlugin {
 					Bukkit.getPluginManager().registerEvents(new BrewingListener(), BukkitPlugin.this);
 				if (serverProtocol > 84 && config.getBoolean("lily-pad-fix"))
 					BoundingBoxFixer.fixLilyPad();
+				if (serverProtocol > 404 && config.getBoolean("carpet-fix")) // 1.14+ only
+					BoundingBoxFixer.fixCarpet();
 				if (serverProtocol > 48 && config.getBoolean("ladder-fix"))
 					BoundingBoxFixer.fixLadder();
 				if (serverProtocol > 47 && config.getBoolean("sound-fix"))

--- a/src/main/java/de/gerrygames/viarewind/legacysupport/injector/BoundingBoxFixer.java
+++ b/src/main/java/de/gerrygames/viarewind/legacysupport/injector/BoundingBoxFixer.java
@@ -26,6 +26,22 @@ public class BoundingBoxFixer {
 		}
 	}
 
+	public static void fixCarpet() {
+		try {
+			int serverProtocol = Via.getAPI().getServerVersion().lowestSupportedVersion();
+			Class<?> blockCarpetClass;
+			if (serverProtocol <= 754) { // 1.16.5
+				blockCarpetClass = NMSReflection.getNMSBlock("BlockCarpet");
+			} else {
+				blockCarpetClass = NMSReflection.getNMSBlock("CarpetBlock");
+			}
+			Field boundingBoxField = ReflectionAPI.getFieldAccessible(blockCarpetClass, "a");
+			setBoundingBox(boundingBoxField.get(0), 0.0D, -0.0000001D, 0.0D, 1.0D, 0.0000001D, 1.0D);
+		} catch (Exception ex) {
+			BukkitPlugin.getInstance().getLogger().log(Level.SEVERE, "Could not fix carpet bounding box.", ex);
+		}
+	}
+
 	public static void fixLadder() {
 		try {
 			Class<?> blockLadderClass = NMSReflection.getNMSBlock("BlockLadder");

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,6 +4,8 @@ brewing-stand-gui-fix: true
 enchanting-gui-fix: true
 #Fix the lily pad bounding box to prevent clients lower than 1.9 from glitching
 lily-pad-fix: true
+#Fix the carpet bounding box to prevent 1.7 clients from glitching on 1.14+ servers
+carpet-fix: true
 #Fix the ladder bounding box to prevent clients lower than 1.9 from glitching
 ladder-fix: true
 #If set to true, this plugin will play sounds for 1.8 and lower that got clientside on 1.9 and higher


### PR DESCRIPTION
Fixes #27.
Why carpet bounding box Y is set to `-0.0000001 -> 0.0000001`:
- Setting it to `0 -> 0` allows entities to fall through it.
- Setting it to `0 -> 0.0000002 (or bigger)` still rubberbands 1.7 players.
- Setting it to `-0.0000002 (or smaller) -> 0` rubberbands players when they hit carpet with the head. (from underneath)

Pre-1.14 servers are not affected as by my observations.
Tested on:
- Paper 1.19
- Paper 1.16.5
- Paper 1.14.4