### PR TITLE
fix: check for return types (optional)

### DIFF
--- a/src/main/java/de/gerrygames/viarewind/legacysupport/injector/NMSReflection.java
+++ b/src/main/java/de/gerrygames/viarewind/legacysupport/injector/NMSReflection.java
@@ -27,6 +27,18 @@ public class NMSReflection {
                 protocolVersion;
     }
 
+    public static Class<?> getBlockDataClass() {
+        try {
+            if (getProtocolVersion() >= PROTOCOL_1_17) {
+                return Class.forName("net.minecraft.world.level.block.state.IBlockData");
+            }
+            return getLegacyNMSClass("IBlockData");
+        } catch (ClassNotFoundException ex) {
+            ex.printStackTrace();
+        }
+        return null;
+    }
+
     public static Class<?> getBlockPositionClass() {
         try {
             if (getProtocolVersion() >= PROTOCOL_1_17) {

--- a/src/main/java/de/gerrygames/viarewind/legacysupport/listener/SoundListener.java
+++ b/src/main/java/de/gerrygames/viarewind/legacysupport/listener/SoundListener.java
@@ -31,6 +31,8 @@ public class SoundListener implements Listener {
 		} catch (ClassNotFoundException ignored) {}
 	}
 
+	private static final Class<?> I_BLOCK_DATA = NMSReflection.getBlockDataClass();
+
 	public SoundListener() {
 		try {
 			Class.forName("org.bukkit.event.entity.EntityPickupItemEvent");
@@ -102,8 +104,8 @@ public class SoundListener implements Listener {
 			}
 			Method getTypeMethod = ReflectionAPI.pickMethod(
 					nmsWorld.getClass(),
-					new MethodSignature("getType", blockPositionClass),
-					new MethodSignature("a_", blockPositionClass) // 1.18.2
+					new MethodSignature("getType", blockPositionClass).withReturnType(I_BLOCK_DATA),
+					new MethodSignature("a_", blockPositionClass).withReturnType(I_BLOCK_DATA) // 1.18.2
 			);
 			Object blockData = getTypeMethod.invoke(nmsWorld, blockPosition);
 			Method getBlock = ReflectionAPI.pickMethod(

--- a/src/main/java/de/gerrygames/viarewind/legacysupport/reflection/MethodSignature.java
+++ b/src/main/java/de/gerrygames/viarewind/legacysupport/reflection/MethodSignature.java
@@ -1,12 +1,15 @@
 package de.gerrygames.viarewind.legacysupport.reflection;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.StringJoiner;
 
 public class MethodSignature {
 
     private final String name;
     private final Class<?>[] parameterTypes;
+
+    private Class<?> returnType;
 
     public MethodSignature(String name, Class<?>... parameterTypes) {
         this.name = name;
@@ -19,6 +22,16 @@ public class MethodSignature {
 
     public Class<?>[] parameterTypes() {
         return parameterTypes;
+    }
+
+    public Class<?> returnType() {
+        return returnType;
+    }
+
+    public MethodSignature withReturnType(Class<?> returnType) {
+        Objects.requireNonNull(returnType);
+        this.returnType = returnType;
+        return this;
     }
 
     @Override

--- a/src/main/java/de/gerrygames/viarewind/legacysupport/reflection/ReflectionAPI.java
+++ b/src/main/java/de/gerrygames/viarewind/legacysupport/reflection/ReflectionAPI.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class ReflectionAPI {
 	private static Map<String, Field> fields = new HashMap<>();
@@ -41,6 +42,9 @@ public class ReflectionAPI {
             for (MethodSignature signature : signatures) {
                 try {
                     Method method = depth.getDeclaredMethod(signature.name(), signature.parameterTypes());
+					if (signature.returnType() != null && !Objects.equals(method.getReturnType(), signature.returnType())) {
+						continue;
+					}
                     if (!method.isAccessible()) {
                         method.setAccessible(true);
                     }


### PR DESCRIPTION
Fixes #50 / #42

Optional parameter for the MethodSignature for validating the returned type by the method as well. Used in the getType-retrieval, as the required method is nested in a superclass, but a method _a is already present in WorldServer.java. By checking the return value, that wrong _a-Method is ignored, as the return type is not the one required.

Tested on 1.16.5 & 1.18.2 - Further testing is appreciated.