### PR TITLE
Add 1.20.5+ support for AreaEffectCloudEmulator spawn particle

### DIFF
--- a/src/main/java/com/viaversion/viarewind/legacysupport/feature/AreaEffectCloudEmulator.java
+++ b/src/main/java/com/viaversion/viarewind/legacysupport/feature/AreaEffectCloudEmulator.java
@@ -18,6 +18,7 @@
 
 package com.viaversion.viarewind.legacysupport.feature;
 
+import com.viaversion.viarewind.legacysupport.util.NMSUtil;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viarewind.legacysupport.BukkitPlugin;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
@@ -45,6 +46,9 @@ public class AreaEffectCloudEmulator implements Listener {
             effectClouds.forEach(cloud -> {
                 final Location location = cloud.getLocation();
                 final float radius = cloud.getRadius();
+                final Object data = NMSUtil.NEWER_THAN_V1_20_5
+                        ? cloud.getColor()
+                        : null;
 
                 float area = (float) Math.PI * radius * radius;
 
@@ -67,7 +71,8 @@ public class AreaEffectCloudEmulator implements Listener {
                                     cloud.getParticle(),
                                     location.getX() + f3, location.getY(), location.getZ() + f6,
                                     0,
-                                    r / 255f, g / 255f, b / 255f
+                                    r / 255f, g / 255f, b / 255f,
+                                    data
                             );
                         });
                     }

--- a/src/main/java/com/viaversion/viarewind/legacysupport/util/NMSUtil.java
+++ b/src/main/java/com/viaversion/viarewind/legacysupport/util/NMSUtil.java
@@ -34,6 +34,8 @@ public class NMSUtil {
     public static String nmsVersionPackage;
     private static Field playerConnectionField;
 
+    public static final boolean NEWER_THAN_V1_20_5 = BukkitPlugin.getInstance().getServerProtocol().newerThanOrEqualTo(ProtocolVersion.v1_20_5);
+
     static {
         if (BukkitPlugin.getInstance().getServerProtocol().olderThan(ProtocolVersion.v1_17)) {
             nmsVersionPackage = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];


### PR DESCRIPTION
Fix https://github.com/ViaVersion/ViaRewind-Legacy-Support/issues/81

Tested on paper-1.8.8-445 / paper-1.20.6-147 / paper-1.21-93, works fine.