### PR TITLE
Fix anvil cost on 1.8 spigot for versions lower than 1.8

### DIFF
--- a/src/main/java/com/viaversion/viarewind/legacysupport/BukkitPlugin.java
+++ b/src/main/java/com/viaversion/viarewind/legacysupport/BukkitPlugin.java
@@ -18,6 +18,7 @@
 
 package com.viaversion.viarewind.legacysupport;
 
+import com.viaversion.viarewind.legacysupport.feature.AnvilCostFix;
 import com.viaversion.viarewind.legacysupport.feature.BlockCollisionChanges;
 import com.viaversion.viarewind.legacysupport.versioninfo.VersionInformer;
 import com.viaversion.viaversion.api.Via;
@@ -58,6 +59,18 @@ public class BukkitPlugin extends JavaPlugin {
         }
 
         final FileConfiguration config = getConfig();
+
+        System.out.println("severProtocol: " + serverProtocol);
+
+        if (serverProtocol.equals(ProtocolVersion.v1_8)) {
+            System.out.println("step 1");
+            if (config.getBoolean("anvil-cost-fix")) {
+                System.out.println("fix 2");
+                Bukkit.getPluginManager().registerEvents(new AnvilCostFix(), BukkitPlugin.this);
+                System.out.println("rgisetered");
+            }
+        }
+
         if (serverProtocol.newerThanOrEqualTo(ProtocolVersion.v1_8)) {
             if (config.getBoolean("enchanting-gui-fix")) {
                 Bukkit.getPluginManager().registerEvents(new EnchantingGuiEmulator(), BukkitPlugin.this);
@@ -66,6 +79,7 @@ public class BukkitPlugin extends JavaPlugin {
                 Bukkit.getPluginManager().registerEvents(new SlimeBounceEmulator(), BukkitPlugin.this);
             }
         }
+
         if (serverProtocol.newerThanOrEqualTo(ProtocolVersion.v1_9)) {
             if (config.getBoolean("sound-fix")) {
                 Bukkit.getPluginManager().registerEvents(new BlockPlaceSoundEmulator(BukkitPlugin.this), BukkitPlugin.this);

--- a/src/main/java/com/viaversion/viarewind/legacysupport/BukkitPlugin.java
+++ b/src/main/java/com/viaversion/viarewind/legacysupport/BukkitPlugin.java
@@ -60,14 +60,9 @@ public class BukkitPlugin extends JavaPlugin {
 
         final FileConfiguration config = getConfig();
 
-        System.out.println("severProtocol: " + serverProtocol);
-
         if (serverProtocol.equals(ProtocolVersion.v1_8)) {
-            System.out.println("step 1");
             if (config.getBoolean("anvil-cost-fix")) {
-                System.out.println("fix 2");
                 Bukkit.getPluginManager().registerEvents(new AnvilCostFix(), BukkitPlugin.this);
-                System.out.println("rgisetered");
             }
         }
 

--- a/src/main/java/com/viaversion/viarewind/legacysupport/feature/AnvilCostFix.java
+++ b/src/main/java/com/viaversion/viarewind/legacysupport/feature/AnvilCostFix.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of ViaRewind-Legacy-Support - https://github.com/ViaVersion/ViaRewind-Legacy-Support
+ * Copyright (C) 2018-2025 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viarewind.legacysupport.feature;
+
+import com.viaversion.viarewind.legacysupport.BukkitPlugin;
+import com.viaversion.viarewind.legacysupport.util.NMSUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.AnvilInventory;
+import org.bukkit.inventory.Inventory;
+import java.util.logging.Level;
+
+public class AnvilCostFix implements Listener {
+    @EventHandler
+    public void onInventoryClickEvent(InventoryClickEvent event) {
+        Inventory inventory = event.getInventory();
+
+        if (inventory instanceof AnvilInventory) {
+            Bukkit.getScheduler().runTaskLater(BukkitPlugin.getInstance(), () -> {
+                for (HumanEntity entity : inventory.getViewers()) {
+                    if (entity instanceof Player) {
+                        refreshAnvilInventoryPlayer((Player) entity);
+                    }
+                }
+            }, 1L);
+        }
+    }
+
+    public void refreshAnvilInventoryPlayer(Player player) {
+        Object nmsPlayer = NMSUtil.getNMSPlayer(player);
+
+        try {
+            Object activeContainer = nmsPlayer.getClass().getField("activeContainer").get(nmsPlayer);
+
+            if (activeContainer.getClass().getSimpleName().equals("ContainerAnvil")) {
+                Object cost = activeContainer.getClass().getField("a").get(activeContainer);
+
+                nmsPlayer.getClass().getMethod("setContainerData", activeContainer.getClass().getSuperclass(), int.class, int.class).invoke(nmsPlayer, activeContainer, cost, cost);
+            }
+        } catch (Exception e) {
+            BukkitPlugin.getInstance().getLogger().log(Level.SEVERE, "Failed to refresh anvil inventory", e);
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,6 +6,9 @@ brewing-stand-gui-fix: true
 # Automatically put lapis lazuli in enchanting tables for clients lower than 1.8
 enchanting-gui-fix: true
 #
+# Fixes anvil cost on 1.8 servers for clients lower than 1.8
+anvil-cost-fix: true
+#
 # Fix the lily pad bounding box to prevent clients lower than 1.9 from glitching
 lily-pad-fix: true
 #


### PR DESCRIPTION
Resolves https://github.com/ViaVersion/ViaRewind/issues/496
Spigot 1.9+ does this broadcast by default as a bukkit event was added to change repair cost