### PR TITLE
Update for plugin remapping removal in Paper 26.1.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ setupProject()
 setupViaPublishing()
 
 dependencies {
-    compileOnly("com.viaversion:viaversion-api:4.10.0")
+    compileOnly("com.viaversion:viaversion-api:5.10.0")
     compileOnly("org.spigotmc:spigot-api:1.16.5-R0.1-SNAPSHOT")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.parallel=true
 org.gradle.configuration-cache=true
 
 # Project Details
-project_jvm_version=8
+project_jvm_version=17
 
 project_group=com.viaversion
 project_version=1.5.5-SNAPSHOT

--- a/src/main/java/com/viaversion/viarewind/legacysupport/feature/BlockCollisionChanges.java
+++ b/src/main/java/com/viaversion/viarewind/legacysupport/feature/BlockCollisionChanges.java
@@ -39,7 +39,7 @@ public class BlockCollisionChanges {
     public static void fixLilyPad(final Logger logger, final ProtocolVersion serverVersion) {
         try {
             final String BlockWaterLilyClassName = NMSUtil.NEWER_THAN_V26_1 ? "LilyPadBlock" : "BlockWaterLily";
-            final String boundingBoxFieldName = NMSUtil.NEWER_THAN_V26_1 ? "SHAPE" : serverVersion.newerThanOrEqualTo(ProtocolVersion.v1_20_2) ? "b" : "a";
+            final String boundingBoxFieldName = NMSUtil.NEWER_THAN_V26_1 ? "SHAPE" : serverVersion.newerThanOrEqualTo(ProtocolVersion.v1_20_3) ? "b" : "a";
             final Field boundingBoxField = getFieldAccessible(getNMSBlockClass(BlockWaterLilyClassName), boundingBoxFieldName);
 
             setBoundingBox(boundingBoxField.get(null), 0.0625, 0.0, 0.0625, 0.9375, 0.015625, 0.9375);
@@ -50,8 +50,8 @@ public class BlockCollisionChanges {
 
     public static void fixCarpet(final Logger logger, final ProtocolVersion serverVersion) {
         try {
-            final String boundingBoxFieldName = NMSUtil.NEWER_THAN_V26_1 ? "SHAPE" : serverVersion.newerThanOrEqualTo(ProtocolVersion.v1_20_2) ? "b" : "a";
-            final String blockCarpetClassName = NMSUtil.NEWER_THAN_V26_1 ? "CarpetBlock" : "BlockCarpet";
+            final String boundingBoxFieldName = NMSUtil.NEWER_THAN_V26_1 ? "SHAPE" : serverVersion.newerThanOrEqualTo(ProtocolVersion.v1_20_3) ? "b" : "a";
+            final String blockCarpetClassName = serverVersion.newerThanOrEqualTo(ProtocolVersion.v1_17) ? "CarpetBlock" : "BlockCarpet";
             final Field boundingBoxField = getFieldAccessible(getNMSBlockClass(blockCarpetClassName), boundingBoxFieldName);
 
             setBoundingBox(boundingBoxField.get(0), 0.0D, -0.0000001D, 0.0D, 1.0D, 0.0000001D, 1.0D);

--- a/src/main/java/com/viaversion/viarewind/legacysupport/feature/BlockCollisionChanges.java
+++ b/src/main/java/com/viaversion/viarewind/legacysupport/feature/BlockCollisionChanges.java
@@ -18,6 +18,7 @@
 
 package com.viaversion.viarewind.legacysupport.feature;
 
+import com.viaversion.viarewind.legacysupport.util.NMSUtil;
 import com.viaversion.viarewind.legacysupport.util.ReflectionUtil;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import java.lang.reflect.Constructor;
@@ -37,7 +38,9 @@ public class BlockCollisionChanges {
 
     public static void fixLilyPad(final Logger logger, final ProtocolVersion serverVersion) {
         try {
-            final Field boundingBoxField = getFieldAccessible(getNMSBlockClass("BlockWaterLily"), serverVersion.olderThanOrEqualTo(ProtocolVersion.v1_20_2) ? "a" : "b");
+            final String BlockWaterLilyClassName = NMSUtil.NEWER_THAN_V26_1 ? "LilyPadBlock" : "BlockWaterLily";
+            final String boundingBoxFieldName = NMSUtil.NEWER_THAN_V26_1 ? "SHAPE" : serverVersion.newerThanOrEqualTo(ProtocolVersion.v1_20_2) ? "b" : "a";
+            final Field boundingBoxField = getFieldAccessible(getNMSBlockClass(BlockWaterLilyClassName), boundingBoxFieldName);
 
             setBoundingBox(boundingBoxField.get(null), 0.0625, 0.0, 0.0625, 0.9375, 0.015625, 0.9375);
         } catch (Exception ex) {
@@ -47,9 +50,10 @@ public class BlockCollisionChanges {
 
     public static void fixCarpet(final Logger logger, final ProtocolVersion serverVersion) {
         try {
-            final Class<?> blockCarpetClass = serverVersion.olderThanOrEqualTo(ProtocolVersion.v1_16_4) ? getNMSBlockClass("BlockCarpet") : getNMSBlockClass("CarpetBlock");
+            final String boundingBoxFieldName = NMSUtil.NEWER_THAN_V26_1 ? "SHAPE" : serverVersion.newerThanOrEqualTo(ProtocolVersion.v1_20_2) ? "b" : "a";
+            final String blockCarpetClassName = NMSUtil.NEWER_THAN_V26_1 ? "CarpetBlock" : "BlockCarpet";
+            final Field boundingBoxField = getFieldAccessible(getNMSBlockClass(blockCarpetClassName), boundingBoxFieldName);
 
-            final Field boundingBoxField = getFieldAccessible(blockCarpetClass, serverVersion.olderThanOrEqualTo(ProtocolVersion.v1_20_2) ? "a" : "b");
             setBoundingBox(boundingBoxField.get(0), 0.0D, -0.0000001D, 0.0D, 1.0D, 0.0000001D, 1.0D);
         } catch (Exception ex) {
             logger.log(Level.SEVERE, "Could not fix carpet bounding box.", ex);
@@ -59,9 +63,9 @@ public class BlockCollisionChanges {
     public static void fixLadder(final Logger logger, final ProtocolVersion serverVersion) {
         try {
             if (serverVersion.newerThanOrEqualTo(ProtocolVersion.v1_20_5)) {
-                final Class<?> blockLadderClass = getNMSBlockClass("BlockLadder");
+                final Class<?> blockLadderClass = getNMSBlockClass(NMSUtil.NEWER_THAN_V26_1 ? "LadderBlock" : "BlockLadder");
 
-                final Map<String, double[]> overrides = new HashMap<String, double[]>();
+                final Map<String, double[]> overrides = new HashMap<>();
                 overrides.put("EAST", new double[]{0.0D, 0.0D, 0.0D, 0.125D, 1.0D, 1.0D});
                 overrides.put("WEST", new double[]{0.875D, 0.0D, 0.0D, 1.0D, 1.0D, 1.0D});
                 overrides.put("SOUTH", new double[]{0.0D, 0.0D, 0.0D, 1.0D, 1.0D, 0.125D});
@@ -187,7 +191,7 @@ public class BlockCollisionChanges {
         // Handle Paper voxel shape caching by clearing the cache
         final Class<?> voxelShape = voxelShapeArray.getClass().getSuperclass();
 
-        final Field shape = getFieldAccessible(voxelShape, "a");
+        final Field shape = getFieldAccessible(voxelShape, NMSUtil.NEWER_THAN_V26_1 ? "shape" : "a");
         final Field cachedShapeData = getFieldAccessible(shape.getType(), "cachedShapeData");
         if (cachedShapeData == null) { // No Paper or too old version
             return;

--- a/src/main/java/com/viaversion/viarewind/legacysupport/feature/ElytraVelocityEmulator.java
+++ b/src/main/java/com/viaversion/viarewind/legacysupport/feature/ElytraVelocityEmulator.java
@@ -41,7 +41,7 @@ public class ElytraVelocityEmulator implements Listener {
             if (nmsPlayer == null) return false;
 
             try {
-                final Method getFlag = ReflectionUtil.getMethod(nmsPlayer.getClass(), "getFlag", int.class);
+                final Method getFlag = ReflectionUtil.findMethod(nmsPlayer.getClass(), new String[]{"getSharedFlag", "getFlag"}, int.class);
                 return (boolean) getFlag.invoke(nmsPlayer, 7);
             } catch (Exception e) {
                 BukkitPlugin.getInstance().getLogger().log(Level.SEVERE, "Failed to get player flag", e);

--- a/src/main/java/com/viaversion/viarewind/legacysupport/util/NMSUtil.java
+++ b/src/main/java/com/viaversion/viarewind/legacysupport/util/NMSUtil.java
@@ -30,7 +30,9 @@ import static com.viaversion.viarewind.legacysupport.util.ReflectionUtil.failSaf
 
 public class NMSUtil {
 
+    public static final boolean NEWER_THAN_V26_1 = BukkitPlugin.getInstance().getServerProtocol().newerThanOrEqualTo(ProtocolVersion.v26_1);
     public static final boolean NEWER_THAN_V1_20_5 = BukkitPlugin.getInstance().getServerProtocol().newerThanOrEqualTo(ProtocolVersion.v1_20_5);
+    public static final boolean NEWER_THAN_V1_17 = BukkitPlugin.getInstance().getServerProtocol().newerThanOrEqualTo(ProtocolVersion.v1_17);
     public static String nmsVersionPackage;
     private static Field playerConnectionField;
 
@@ -41,7 +43,9 @@ public class NMSUtil {
     }
 
     public static Class<?> getBlockPositionClass() {
-        if (BukkitPlugin.getInstance().getServerProtocol().newerThanOrEqualTo(ProtocolVersion.v1_17)) {
+        if (NEWER_THAN_V26_1) {
+            return failSafeGetClass("net.minecraft.core.BlockPos");
+        } else if (NEWER_THAN_V1_17) {
             return failSafeGetClass("net.minecraft.core.BlockPosition");
         } else {
             return getLegacyNMSClass("BlockPosition");
@@ -49,7 +53,7 @@ public class NMSUtil {
     }
 
     public static Class<?> getNMSBlockClass(final String name) {
-        if (BukkitPlugin.getInstance().getServerProtocol().newerThanOrEqualTo(ProtocolVersion.v1_17)) {
+        if (NEWER_THAN_V1_17) {
             return failSafeGetClass("net.minecraft.world.level.block." + name);
         } else {
             return getLegacyNMSClass(name);
@@ -57,7 +61,9 @@ public class NMSUtil {
     }
 
     public static Class getSoundCategoryClass() { // Bypass generics
-        if (BukkitPlugin.getInstance().getServerProtocol().newerThanOrEqualTo(ProtocolVersion.v1_17)) {
+        if (NEWER_THAN_V26_1) {
+            return failSafeGetClass("net.minecraft.sounds.SoundSource");
+        } else if (NEWER_THAN_V1_17) {
             return failSafeGetClass("net.minecraft.sounds.SoundCategory");
         } else {
             return getLegacyNMSClass("SoundCategory");
@@ -65,7 +71,7 @@ public class NMSUtil {
     }
 
     public static Class<?> getPacketClass() {
-        if (BukkitPlugin.getInstance().getServerProtocol().newerThanOrEqualTo(ProtocolVersion.v1_17)) {
+        if (NEWER_THAN_V1_17) {
             return failSafeGetClass("net.minecraft.network.protocol.Packet");
         } else {
             return getLegacyNMSClass("Packet");
@@ -73,7 +79,7 @@ public class NMSUtil {
     }
 
     public static Class<?> getGamePacketClass(final String packet) {
-        if (BukkitPlugin.getInstance().getServerProtocol().newerThanOrEqualTo(ProtocolVersion.v1_17)) {
+        if (NEWER_THAN_V1_17) {
             return failSafeGetClass("net.minecraft.network.protocol.game." + packet);
         } else {
             return getLegacyNMSClass(packet);
@@ -81,7 +87,9 @@ public class NMSUtil {
     }
 
     public static Class<?> getPlayerConnectionClass() {
-        if (BukkitPlugin.getInstance().getServerProtocol().newerThanOrEqualTo(ProtocolVersion.v1_17)) {
+        if (NEWER_THAN_V26_1) {
+            return failSafeGetClass("net.minecraft.server.network.ServerGamePacketListenerImpl");
+        } else if (NEWER_THAN_V1_17) {
             return failSafeGetClass("net.minecraft.server.network.PlayerConnection");
         } else {
             return getLegacyNMSClass("PlayerConnection");


### PR DESCRIPTION
Update for plugin remapping removal in Paper 26.1.2. This PR also bumped the minimal Java requirement to 17, due to Via API's requirement.